### PR TITLE
Update llms.txt plugin

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -18,7 +18,7 @@
         "vitepress": "^1.6.3",
         "vitepress-plugin-tabs": "^0.7.1",
         "vitepress-sidebar": "^1.32.1",
-        "vitepress-plugin-llmstxt": "^0.3.2"
+        "vitepress-plugin-llmstxt": "^0.4.2"
     },
     "dependencies": {
         "docs": "file:"


### PR DESCRIPTION
^0.4.0 resolves build size issues:  https://github.com/angelespejo/vitepress-plugin-llmstxt/issues/3