### PR TITLE
fix (analysis): Obey openFilesOnly in analysis

### DIFF
--- a/packages/language_server/src/robotcode/language_server/common/parts/diagnostics.py
+++ b/packages/language_server/src/robotcode/language_server/common/parts/diagnostics.py
@@ -349,7 +349,15 @@ class DiagnosticsProtocolPart(LanguageServerProtocolPart):
                 self._break_diagnostics_loop_event.clear()
 
                 documents = sorted(
-                    [doc for doc in self.parent.documents.documents if self._doc_need_update(doc)],
+                    [
+                        doc
+                        for doc in self.parent.documents.documents
+                        if self._doc_need_update(doc)
+                        and (
+                            doc.opened_in_editor
+                            or self.get_diagnostics_mode(doc.uri) == DiagnosticsMode.WORKSPACE
+                        )
+                    ],
                     key=lambda d: not d.opened_in_editor,
                 )
 
@@ -436,7 +444,7 @@ class DiagnosticsProtocolPart(LanguageServerProtocolPart):
                 documents_to_collect = [
                     doc
                     for doc in documents
-                    if doc.opened_in_editor or self.get_diagnostics_mode(document.uri) == DiagnosticsMode.WORKSPACE
+                    if doc.opened_in_editor or self.get_diagnostics_mode(doc.uri) == DiagnosticsMode.WORKSPACE
                 ]
 
                 with self._logger.measure_time(

--- a/packages/language_server/src/robotcode/language_server/robotframework/parts/robot_workspace.py
+++ b/packages/language_server/src/robotcode/language_server/robotframework/parts/robot_workspace.py
@@ -58,6 +58,16 @@ class RobotWorkspaceProtocolPart(RobotLanguageServerProtocolPart):
                 for folder in self.parent.workspace.workspace_folders:
                     config = self.parent.workspace.get_configuration(RobotCodeConfig, folder.uri)
 
+                    if config.analysis.diagnostic_mode != DiagnosticsMode.WORKSPACE:
+                        self._logger.debug(
+                            lambda: (
+                                f"Skip loading workspace documents for {folder.uri.to_path()} "
+                                f"because analysis.diagnosticMode={config.analysis.diagnostic_mode.value!r}"
+                            ),
+                            context_name="load_workspace_documents",
+                        )
+                        continue
+
                     extensions = [ROBOT_FILE_EXTENSION, RESOURCE_FILE_EXTENSION]
 
                     exclude_patterns = [


### PR DESCRIPTION
If robotcode.analysis.diagnosticMode is set to openFilesOnly, then do analysis only for open files, not for all workspace files.  Fix also a collect phase bug: evaluate the mode from the own mode of the document in comparison.