### PR TITLE
fix(vscode): update stale RF version UI strings from 4.1 to 5.0

### DIFF
--- a/vscode-client/extension/languageclientsmanger.ts
+++ b/vscode-client/extension/languageclientsmanger.ts
@@ -366,7 +366,7 @@ export class LanguageClientsManager {
           id: "select",
           label: "Select Python Interpreter...",
           detail:
-            "Choose a Python interpreter version 3.10 or newer that has `robotframework` version 4.1 or higher installed",
+            "Choose a Python interpreter version 3.10 or newer that has `robotframework` version 5.0 or higher installed",
         },
         {
           id: "create",
@@ -379,7 +379,7 @@ export class LanguageClientsManager {
                 id: "retry",
                 label: "Retry",
                 detail:
-                  "Install `robotframework` version 4.1 or higher manually in the current environment, then restart the language server",
+                  "Install `robotframework` version 5.0 or higher manually in the current environment, then restart the language server",
               },
             ]
           : []),


### PR DESCRIPTION
The quick-pick dialog shown when environment validation fails referenced 'robotframework version 4.1 or higher' in both the 'Select Python Interpreter' detail and the 'Retry' detail text.

The actual enforced minimum has been 5.0 since commit `02cf495f` (`refactor: introduce RF_VERSION constant and remove RF < 5.0 dead code`, March 30 2026).

This PR updates the two stale strings in `vscode-client/extension/languageclientsmanger.ts` to say '5.0 or higher'.

Closes #603