### PR TITLE
Security: Unsafe eval in safe_eval.py allows code injection via globals parameter

### DIFF
--- a/packages/core/src/robotcode/core/utils/safe_eval.py
+++ b/packages/core/src/robotcode/core/utils/safe_eval.py
@@ -54,9 +54,9 @@ class Transformer(ast.NodeTransformer):
         return self.generic_visit(node)
 
 
-def safe_eval(source: str, globals: Dict[str, Any] = {}, filename: str = "<expression>") -> Any:
-    transformer = Transformer(list(globals.keys()))
+def safe_eval(source: str, filename: str = "<expression>") -> Any:
+    transformer = Transformer(None)
     tree = ast.parse(source, mode="eval")
     tree = transformer.visit(tree)
     clause = compile(tree, filename, "eval", dont_inherit=True)
-    return eval(clause, globals, {})
+    return eval(clause, {}, {})


### PR DESCRIPTION
## Summary

Security: Unsafe eval in safe_eval.py allows code injection via globals parameter

## Problem

**Severity**: `High` | **File**: `packages/core/src/robotcode/core/utils/safe_eval.py:L50`

The `safe_eval` function in `safe_eval.py` accepts a `globals` parameter that is passed directly to `eval()`. While the `Transformer` class restricts access to names, the `globals` dictionary can contain arbitrary callables or objects that bypass name-based restrictions. An attacker could pass a crafted `globals` dict with `__import__`, `open`, or other dangerous builtins disguised as allowed names, or use dunder methods on allowed types to execute arbitrary code. The function also uses `eval()` with `compile()` output, which can still execute arbitrary code if the AST is not fully sanitized.

## Solution

Remove the `globals` parameter entirely, or strictly validate all values in the globals dict to ensure they are not callable and do not have dangerous dunder methods. Consider using `ast.literal_eval` instead of `eval` for simple data structures, or implement a proper sandbox using `RestrictedPython`.

## Changes

- `packages/core/src/robotcode/core/utils/safe_eval.py` (modified)