### PR TITLE
fix(runner): preserve multiline message text in results truncation

### DIFF
--- a/packages/runner/src/robotcode/runner/cli/results/results.py
+++ b/packages/runner/src/robotcode/runner/cli/results/results.py
@@ -1146,10 +1146,11 @@ def _make_diff_change(
 def _truncate(text: Optional[str], limit: int) -> Optional[str]:
     if not text:
         return None
-    first_line = text.splitlines()[0]
-    if limit and len(first_line) > limit:
-        return first_line[:limit].rstrip() + "…"
-    return first_line
+    if not limit:
+        return text
+    if len(text) > limit:
+        return text[:limit].rstrip() + "…"
+    return text
 
 
 def _resolve_profile(app: Application) -> Tuple[RobotBaseProfile, Optional[Path]]:
@@ -1529,11 +1530,11 @@ def _make_file_info(path: Path) -> ResultFileInfo:
 
 def _make_test_item(test: TestCase, *, message_chars: int) -> TestResultItem:
     msg = test.message or ""
-    first_line = msg.splitlines()[0] if msg else ""
-    truncated_msg = first_line
     full_msg: Optional[str] = None
-    if message_chars and len(first_line) > message_chars:
-        truncated_msg = first_line[:message_chars]
+    if message_chars and len(msg) > message_chars:
+        truncated_msg = msg[:message_chars]
+    else:
+        truncated_msg = msg
     if msg and (truncated_msg != msg):
         full_msg = msg
 


### PR DESCRIPTION
## Summary

Changes results, show and diff to show multiple lines of messages up to the message-char limit, fixes #625 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] Build / CI / tooling
- [ ] Breaking change

## Checklist

- [x] I have read the [Contribution Guide](../CONTRIBUTING.md) and the [AI and Automated Contribution Policy](../AI_POLICY.md).
- [x] The change is focused on a single concern (no unrelated refactors or formatting noise).
- [x] Tests for the change have been added or updated, and `hatch run test:test` passes locally (RF matrix against the default Python) — *or N/A for documentation-only / non-code changes*. See [Running Tests](../CONTRIBUTING.md#running-tests) for faster iteration options and the full matrix.
- [x] `hatch run lint:all` passes (also enforced by the [pre-commit hooks](../CONTRIBUTING.md#pre-commit-hooks) if installed) — *or N/A for documentation-only / non-code changes*.
- [ ] Documentation has been updated where relevant (user docs, code comments, README).
- [ ] Generated files (if any) were regenerated with the documented script, not edited by hand.
- [x] Commits follow [Conventional Commits](../CONTRIBUTING.md#commit-messages) and are [cryptographically signed](../CONTRIBUTING.md#signed-commits-required) (`git commit -S`, GPG/SSH).

## AI / tooling disclosure

- [x] No AI/automation was used beyond ordinary editor autocomplete.
- [ ] AI/automation was used; tool(s): <!-- e.g. GitHub Copilot, Claude, ... -->
  - [ ] I reviewed the generated output manually, understand it, and verified it locally.