### PR TITLE
feat(robot): allow conditional no-status-rc

### DIFF
--- a/docs/03_reference/config.md
+++ b/docs/03_reference/config.md
@@ -1329,7 +1329,7 @@ corresponds to the `-N --name name` option of _robot_
 
 ## no-status-rc
 
-Type: `bool | Flag | None`
+Type: `bool | Flag | Condition | None`
 
 Sets the return code to zero regardless of failures
 in test cases. Error codes are returned normally.
@@ -1339,6 +1339,11 @@ Examples:
 ```toml
 # always exit 0 regardless of failed tests
 no-status-rc = true
+```
+
+```toml
+# decide from the current branch
+no-status-rc = { if = "environ.get('CI_COMMIT_REF_NAME') == 'main'" }
 ```
 
 corresponds to the `--nostatusrc` option of _robot_
@@ -2271,7 +2276,7 @@ corresponds to the `-N --name name` option of _robot_
 
 ## rebot.no-status-rc
 
-Type: `bool | Flag | None`
+Type: `bool | Flag | Condition | None`
 
 Sets the return code to zero regardless of failures
 in test cases. Error codes are returned normally.
@@ -2281,6 +2286,11 @@ Examples:
 ```toml
 # always exit 0 regardless of failed tests
 no-status-rc = true
+```
+
+```toml
+# decide from the current branch
+no-status-rc = { if = "environ.get('CI_COMMIT_REF_NAME') == 'main'" }
 ```
 
 corresponds to the `--nostatusrc` option of _robot_

--- a/docs/public/schemas/robot.toml.json
+++ b/docs/public/schemas/robot.toml.json
@@ -559,12 +559,7 @@
           ],
           "markdownDescription": "Condition to evaluate. This must be a Python \"eval\" expression.\nFor security reasons, only certain expressions and functions are allowed.\n\nExamples:\n```toml\nif = \"re.match(r'^\\d+$', environ.get('TEST_VAR', ''))\"\nif = \"platform.system() == 'Linux'\"\n```\n\nsee also `expr` for allowed global names.\n",
           "title": "If",
-          "type": "string",
-          "x-taplo": {
-            "links": {
-              "key": "https://robotcode.io/03_reference/config#no-status-rc-if"
-            }
-          }
+          "type": "string"
         }
       },
       "required": [

--- a/docs/public/schemas/robot.toml.json
+++ b/docs/public/schemas/robot.toml.json
@@ -562,7 +562,7 @@
           "type": "string",
           "x-taplo": {
             "links": {
-              "key": "https://robotcode.io/03_reference/config#profile-enabled-if"
+              "key": "https://robotcode.io/03_reference/config#no-status-rc-if"
             }
           }
         }
@@ -2168,15 +2168,19 @@
               ]
             },
             {
+              "$ref": "#/definitions/Condition"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Sets the return code to zero regardless of failures\nin test cases. Error codes are returned normally.\n\nExamples:\n\n```toml\n# always exit 0 regardless of failed tests\nno-status-rc = true\n```\n\ncorresponds to the `--nostatusrc` option of _robot_\n",
+          "description": "Sets the return code to zero regardless of failures\nin test cases. Error codes are returned normally.\n\nExamples:\n\n```toml\n# always exit 0 regardless of failed tests\nno-status-rc = true\n```\n\n```toml\n# decide from the current branch\nno-status-rc = { if = \"environ.get('CI_COMMIT_REF_NAME') == 'main'\" }\n```\n\ncorresponds to the `--nostatusrc` option of _robot_\n",
           "examples": [
-            "# always exit 0 regardless of failed tests\nno-status-rc = true"
+            "# always exit 0 regardless of failed tests\nno-status-rc = true",
+            "# decide from the current branch\nno-status-rc = { if = \"environ.get('CI_COMMIT_REF_NAME') == 'main'\" }"
           ],
-          "markdownDescription": "Sets the return code to zero regardless of failures\nin test cases. Error codes are returned normally.\n\nExamples:\n\n```toml\n# always exit 0 regardless of failed tests\nno-status-rc = true\n```\n\ncorresponds to the `--nostatusrc` option of _robot_\n",
+          "markdownDescription": "Sets the return code to zero regardless of failures\nin test cases. Error codes are returned normally.\n\nExamples:\n\n```toml\n# always exit 0 regardless of failed tests\nno-status-rc = true\n```\n\n```toml\n# decide from the current branch\nno-status-rc = { if = \"environ.get('CI_COMMIT_REF_NAME') == 'main'\" }\n```\n\ncorresponds to the `--nostatusrc` option of _robot_\n",
           "title": "No Status Rc",
           "x-taplo": {
             "links": {
@@ -4866,15 +4870,19 @@
               ]
             },
             {
+              "$ref": "#/definitions/Condition"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Sets the return code to zero regardless of failures\nin test cases. Error codes are returned normally.\n\nExamples:\n\n```toml\n# always exit 0 regardless of failed tests\nno-status-rc = true\n```\n\ncorresponds to the `--nostatusrc` option of _robot_\n",
+          "description": "Sets the return code to zero regardless of failures\nin test cases. Error codes are returned normally.\n\nExamples:\n\n```toml\n# always exit 0 regardless of failed tests\nno-status-rc = true\n```\n\n```toml\n# decide from the current branch\nno-status-rc = { if = \"environ.get('CI_COMMIT_REF_NAME') == 'main'\" }\n```\n\ncorresponds to the `--nostatusrc` option of _robot_\n",
           "examples": [
-            "# always exit 0 regardless of failed tests\nno-status-rc = true"
+            "# always exit 0 regardless of failed tests\nno-status-rc = true",
+            "# decide from the current branch\nno-status-rc = { if = \"environ.get('CI_COMMIT_REF_NAME') == 'main'\" }"
           ],
-          "markdownDescription": "Sets the return code to zero regardless of failures\nin test cases. Error codes are returned normally.\n\nExamples:\n\n```toml\n# always exit 0 regardless of failed tests\nno-status-rc = true\n```\n\ncorresponds to the `--nostatusrc` option of _robot_\n",
+          "markdownDescription": "Sets the return code to zero regardless of failures\nin test cases. Error codes are returned normally.\n\nExamples:\n\n```toml\n# always exit 0 regardless of failed tests\nno-status-rc = true\n```\n\n```toml\n# decide from the current branch\nno-status-rc = { if = \"environ.get('CI_COMMIT_REF_NAME') == 'main'\" }\n```\n\ncorresponds to the `--nostatusrc` option of _robot_\n",
           "title": "No Status Rc",
           "x-taplo": {
             "links": {
@@ -8107,15 +8115,19 @@
               ]
             },
             {
+              "$ref": "#/definitions/Condition"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Sets the return code to zero regardless of failures\nin test cases. Error codes are returned normally.\n\nExamples:\n\n```toml\n# always exit 0 regardless of failed tests\nno-status-rc = true\n```\n\ncorresponds to the `--nostatusrc` option of _robot_\n",
+          "description": "Sets the return code to zero regardless of failures\nin test cases. Error codes are returned normally.\n\nExamples:\n\n```toml\n# always exit 0 regardless of failed tests\nno-status-rc = true\n```\n\n```toml\n# decide from the current branch\nno-status-rc = { if = \"environ.get('CI_COMMIT_REF_NAME') == 'main'\" }\n```\n\ncorresponds to the `--nostatusrc` option of _robot_\n",
           "examples": [
-            "# always exit 0 regardless of failed tests\nno-status-rc = true"
+            "# always exit 0 regardless of failed tests\nno-status-rc = true",
+            "# decide from the current branch\nno-status-rc = { if = \"environ.get('CI_COMMIT_REF_NAME') == 'main'\" }"
           ],
-          "markdownDescription": "Sets the return code to zero regardless of failures\nin test cases. Error codes are returned normally.\n\nExamples:\n\n```toml\n# always exit 0 regardless of failed tests\nno-status-rc = true\n```\n\ncorresponds to the `--nostatusrc` option of _robot_\n",
+          "markdownDescription": "Sets the return code to zero regardless of failures\nin test cases. Error codes are returned normally.\n\nExamples:\n\n```toml\n# always exit 0 regardless of failed tests\nno-status-rc = true\n```\n\n```toml\n# decide from the current branch\nno-status-rc = { if = \"environ.get('CI_COMMIT_REF_NAME') == 'main'\" }\n```\n\ncorresponds to the `--nostatusrc` option of _robot_\n",
           "title": "No Status Rc",
           "x-taplo": {
             "links": {

--- a/packages/robot/src/robotcode/robot/config/model.py
+++ b/packages/robot/src/robotcode/robot/config/model.py
@@ -682,7 +682,7 @@ class CommonOptions(RobotBaseOptions):
         robot_priority=500,
         robot_short_name="N",
     )
-    no_status_rc: Union[bool, Flag, None] = field(
+    no_status_rc: Union[bool, Flag, Condition, None] = field(
         description="""\
             Sets the return code to zero regardless of failures
             in test cases. Error codes are returned normally.
@@ -692,6 +692,11 @@ class CommonOptions(RobotBaseOptions):
             ```toml
             # always exit 0 regardless of failed tests
             no-status-rc = true
+            ```
+
+            ```toml
+            # decide from the current branch
+            no-status-rc = { if = "environ.get('CI_COMMIT_REF_NAME') == 'main'" }
             ```
 
             corresponds to the `--nostatusrc` option of _robot_

--- a/scripts/create_robot_toml_json_schema.py
+++ b/scripts/create_robot_toml_json_schema.py
@@ -248,6 +248,16 @@ def _post_process_schema(
     if isinstance(root_ref, str) and root_ref.startswith("#/$defs/"):
         process_def(root_ref.rsplit("/", 1)[-1], "")
 
+    # Condition is shared by enabled, hidden, and conditional flag fields, so
+    # its nested key has no single context-independent documentation anchor.
+    condition_schema = defs.get("Condition")
+    if isinstance(condition_schema, dict):
+        condition_properties = condition_schema.get("properties")
+        if isinstance(condition_properties, dict):
+            condition_if = condition_properties.get("if")
+            if isinstance(condition_if, dict):
+                condition_if.pop("x-taplo", None)
+
 
 def _convert_to_draft7_schema(schema_dict: dict) -> None:
     """Convert generated schema to draft-07 compatible structure in-place."""

--- a/scripts/generate_rf_options.py
+++ b/scripts/generate_rf_options.py
@@ -87,7 +87,7 @@ TOML_EXAMPLES: Dict[str, List[str]] = {
     # --- numeric options ---
     "--consolewidth": ["console-width = 100"],
     "--maxassignlength": ["max-assign-length = 200"],
-    "--maxerrorlines": ["max-error-lines = 40"],
+    "--maxerrorlines": ["max-error-lines = 40", 'max-error-lines = "NONE"'],
     "--suitestatlevel": ["suite-stat-level = 2"],
     # --- single-string options (paths, names, titles, timestamps) ---
     "--debugfile": ['debug-file = "debug.log"'],
@@ -161,6 +161,7 @@ TOML_EXAMPLES: Dict[str, List[str]] = {
     "--splitlog": ["split-log = true"],
     "--nostatusrc": [
         "# always exit 0 regardless of failed tests\nno-status-rc = true",
+        "# decide from the current branch\nno-status-rc = { if = \"environ.get('CI_COMMIT_REF_NAME') == 'main'\" }",
     ],
     "--timestampoutputs": ["timestamp-outputs = true"],
 }
@@ -345,6 +346,8 @@ def generate(
     ) -> str:
         if not option.get("param"):
             if is_flag:
+                if name == "no_status_rc":
+                    return "Union[bool, Flag, Condition, None]"
                 return "Union[bool, Flag, None]"
 
             return "Optional[bool]"
@@ -421,6 +424,9 @@ def generate(
                         output.append("        robot_is_flag=True,")
                         if not flag_default:
                             output.append(f"        robot_flag_default={flag_default},")
+                alias = name.replace("_", "-")
+                if alias != name:
+                    output.append(f'        alias="{alias}",')
                 output.append("    )")
 
         return result
@@ -548,6 +554,8 @@ generate(
     extra=True,
     tool="testdoc",
 )
+
+output.extend(["", ""])
 
 model_file = Path("packages/robot/src/robotcode/robot/config/model.py")
 original_lines = model_file.read_text().splitlines()

--- a/tests/robotcode/robot/config/test_profile.py
+++ b/tests/robotcode/robot/config/test_profile.py
@@ -414,24 +414,6 @@ def test_no_status_rc_accepts_conditions(
     assert _status_rc_flags(f'{section}no-status-rc = {{ if = "{condition}" }}', rebot=rebot) == expected
 
 
-@pytest.mark.parametrize(
-    ("branch", "expected"),
-    [("main", ["--nostatusrc"]), ("feature/example", ["--statusrc"])],
-)
-def test_profile_no_status_rc_condition_uses_ci_commit_ref_name(
-    monkeypatch: pytest.MonkeyPatch,
-    branch: str,
-    expected: list[str],
-) -> None:
-    monkeypatch.setenv("CI_COMMIT_REF_NAME", branch)
-    data = """\
-        [profiles.ci]
-        no-status-rc = { if = "environ.get('CI_COMMIT_REF_NAME') == 'main'" }
-    """
-
-    assert _status_rc_flags(data, "ci") == expected
-
-
 def test_no_status_rc_rejects_invalid_condition() -> None:
     data = """\
         [profiles.ci]

--- a/tests/robotcode/robot/config/test_profile.py
+++ b/tests/robotcode/robot/config/test_profile.py
@@ -374,3 +374,75 @@ def test_type_that_wants_alist_should_throw_an_error() -> None:
             """
     with pytest.raises(TypeError, match=r".*Value '.*' must be of type.*"):
         load_robot_config_from_robot_toml_str(data)
+
+
+_STATUS_RC_FLAGS = {"--nostatusrc", "--statusrc"}
+
+
+def _status_rc_flags(data: str, *profiles: str, rebot: bool = False) -> list[str]:
+    config = load_robot_config_from_robot_toml_str(data)
+    options = config.rebot if rebot else config.combine_profiles(*profiles)
+    assert options is not None
+    return [arg for arg in options.evaluated().build_command_line() if arg in _STATUS_RC_FLAGS]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("true", ["--nostatusrc"]),
+        ("false", ["--statusrc"]),
+        ('"on"', ["--nostatusrc"]),
+        ('"off"', ["--statusrc"]),
+        ('"default"', []),
+    ],
+)
+def test_no_status_rc_literals_keep_flag_semantics(value: str, expected: list[str]) -> None:
+    assert _status_rc_flags(f"no-status-rc = {value}") == expected
+
+
+@pytest.mark.parametrize(("section", "rebot"), [("", False), ("[rebot]\n", True)])
+@pytest.mark.parametrize(
+    ("condition", "expected"),
+    [("True", ["--nostatusrc"]), ("False", ["--statusrc"])],
+)
+def test_no_status_rc_accepts_conditions(
+    section: str,
+    rebot: bool,
+    condition: str,
+    expected: list[str],
+) -> None:
+    assert _status_rc_flags(f'{section}no-status-rc = {{ if = "{condition}" }}', rebot=rebot) == expected
+
+
+@pytest.mark.parametrize(
+    ("branch", "expected"),
+    [("main", ["--nostatusrc"]), ("feature/example", ["--statusrc"])],
+)
+def test_profile_no_status_rc_condition_uses_ci_commit_ref_name(
+    monkeypatch: pytest.MonkeyPatch,
+    branch: str,
+    expected: list[str],
+) -> None:
+    monkeypatch.setenv("CI_COMMIT_REF_NAME", branch)
+    data = """\
+        [profiles.ci]
+        no-status-rc = { if = "environ.get('CI_COMMIT_REF_NAME') == 'main'" }
+    """
+
+    assert _status_rc_flags(data, "ci") == expected
+
+
+def test_no_status_rc_rejects_invalid_condition() -> None:
+    data = """\
+        [profiles.ci]
+        no-status-rc = { if = "environ.get('CI') = 'true'" }
+    """
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^Evaluation of 'no_status_rc' failed: EvaluationError: "
+            r"Evaluation of \"environ\.get\('CI'\) = 'true'\" failed: invalid syntax"
+        ),
+    ):
+        _status_rc_flags(data, "ci")

--- a/tests/robotcode/robot/config/test_schema.py
+++ b/tests/robotcode/robot/config/test_schema.py
@@ -1,0 +1,10 @@
+import json
+from pathlib import Path
+
+
+def test_shared_condition_has_no_context_specific_documentation_link() -> None:
+    schema_path = Path(__file__).parents[4] / "docs/public/schemas/robot.toml.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    condition_if = schema["definitions"]["Condition"]["properties"]["if"]
+
+    assert "x-taplo" not in condition_if

--- a/tests/robotcode/runner/cli/test_conditional_no_status_rc.py
+++ b/tests/robotcode/runner/cli/test_conditional_no_status_rc.py
@@ -1,0 +1,64 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("branch", "expected_flag", "expected_returncode"),
+    [
+        ("main", "--nostatusrc", 0),
+        ("feature/example", "--statusrc", 1),
+    ],
+)
+def test_ci_profile_conditional_no_status_rc_controls_robot_exit_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    branch: str,
+    expected_flag: str,
+    expected_returncode: int,
+) -> None:
+    (tmp_path / "robot.toml").write_text(
+        """\
+default-profiles = ["ci"]
+
+[profiles.ci]
+enabled = { if = "environ.get('CI') == 'true'" }
+no-status-rc = { if = "environ.get('CI_COMMIT_REF_NAME') == 'main'" }
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "suite.robot").write_text(
+        """\
+*** Test Cases ***
+Fails
+    Fail    expected failure
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("CI_COMMIT_REF_NAME", branch)
+    user_dir = tmp_path / "user"
+    for name in ("HOME", "XDG_CONFIG_HOME", "APPDATA", "LOCALAPPDATA"):
+        monkeypatch.setenv(name, str(user_dir))
+    monkeypatch.setenv("ROBOTCODE_CACHE_DIR", str(tmp_path / "cache"))
+
+    result = subprocess.run(
+        [sys.executable, "-m", "robotcode.cli", "--verbose", "run", "suite.robot"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=os.environ.copy(),
+    )
+    output = result.stdout + result.stderr
+    unexpected_flag = "--statusrc" if expected_flag == "--nostatusrc" else "--nostatusrc"
+
+    assert result.returncode == expected_returncode, output
+    assert "Selected profiles: ci" in output
+    assert 'Using profile "ci".' in output
+    assert "1 test, 0 passed, 1 failed" in output
+    assert expected_flag in output
+    assert unexpected_flag not in output


### PR DESCRIPTION
## Summary

Allow `no-status-rc` to accept the existing `Condition` form, enabling branch-dependent status-code behavior without duplicating profiles:

```toml
default-profiles = ["ci"]

[profiles.ci]
enabled = { if = "environ.get('CI') == 'true'" }
no-status-rc = { if = "environ.get('CI_COMMIT_REF_NAME') == 'main'" }
```

A failing Robot run now returns `0` on `main` and preserves the failure status on feature branches. Existing `true`, `false`, `on`, `off`, and `default` behavior remains unchanged.

Fixes #482.

### Design choice

I prototyped both designs raised in the issue against the same 12 behavioral cases:

- Reuse `Condition { if = ... }`.
- Add a public `BoolExpression { expr = ... }` type.

Both produced the required boolean flag behavior. I kept `Condition` because it matches the requested syntax, reuses the existing safe evaluation path, and avoids another public model and schema definition. The conditional form resolves to `true` or `false`; static `default` remains available through the existing literal form.

Because `Condition` is now shared by profile fields and a flag field, the schema generator also avoids attaching a context-specific documentation link to its shared `if` property.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / internal change
- [x] Documentation
- [ ] Build / CI / tooling
- [ ] Breaking change

## Checklist

- [x] I have read the [Contribution Guide](../CONTRIBUTING.md) and the [AI and Automated Contribution Policy](../AI_POLICY.md).
- [x] The change is focused on a single concern (no unrelated refactors or formatting noise).
- [x] Tests for the change have been added or updated, and `hatch run test:test` passes locally (RF matrix against the default Python) — *or N/A for documentation-only / non-code changes*. See [Running Tests](../CONTRIBUTING.md#running-tests) for faster iteration options and the full matrix.
- [ ] `hatch run lint:all` passes (also enforced by the [pre-commit hooks](../CONTRIBUTING.md#pre-commit-hooks) if installed) — *or N/A for documentation-only / non-code changes*.
- [x] Documentation has been updated where relevant (user docs, code comments, README).
- [x] Generated files (if any) were regenerated with the documented script, not edited by hand.
- [x] Commits follow [Conventional Commits](../CONTRIBUTING.md#commit-messages) and are [cryptographically signed](../CONTRIBUTING.md#signed-commits-required) (`git commit -S`, GPG/SSH).

## AI / tooling disclosure

- [ ] No AI/automation was used beyond ordinary editor autocomplete.
- [x] AI/automation was used; tool(s): OpenAI Codex through Agent Orchestrator
  - [x] I reviewed the generated output manually, understand it, and verified it locally.

> AI/tooling disclosure: This contribution was prepared with assistance from OpenAI Codex through Agent Orchestrator. I manually reviewed the diff, understand the implementation, verified it locally, and confirm that I have the right to submit it under the project license.

## Additional notes

### Acceptance proof

The end-to-end test uses the configuration shown above, selects the single `ci` profile through `default-profiles`, and runs a deliberately failing Robot suite through a real RobotCode subprocess without `-p`:

- `CI=true`, `CI_COMMIT_REF_NAME=main`: `--nostatusrc`, exit code `0`.
- `CI=true`, `CI_COMMIT_REF_NAME=feature/example`: `--statusrc`, exit code `1`.

The same test fails on unmodified `main` while parsing `profiles.ci.no_status_rc` because the conditional table is not accepted there.

### Verification

- `hatch run test:test`: passed across `rf50`, `rf60`, `rf61`, and `rf70` through `rf74`; the final `rf74` run reported 3933 passed, 22 skipped, and 2 xfailed.
- Focused matrix: 28 tests passed in each of the eight Robot Framework environments.
- Ruff check and formatting stages: passed; 413 files already formatted.
- JSON Schema Draft 7 validation: passed.
- Generator idempotence: repeated model and schema generation produced identical hashes.
- `git diff --check`: passed.

A fresh `hatch run lint:all` reaches one mypy 2.2.0 `comparison-overlap` error in the untouched `packages/plugin/src/robotcode/plugin/__init__.py:352`. The same error reproduces on unmodified `main`; Ruff and all feature-related tests pass. The lint checklist remains intentionally unchecked.

### Generated artifacts

The model and schema were regenerated with:

```shell
hatch run test.rf74:python scripts/generate_rf_options.py
hatch run test.rf74:ruff format packages/robot/src/robotcode/robot/config/model.py
hatch run test.rf74:python scripts/create_robot_toml_json_schema.py
```

The updated `no-status-rc` documentation matches the generated model output. Generator compatibility adjustments preserve existing field aliases, the existing `max-error-lines = "NONE"` example, and generated-block spacing so regeneration does not introduce unrelated output drift.
